### PR TITLE
Fix cosmetic dark mode issue (fixes #122)

### DIFF
--- a/missalemeum/static/js/common.js
+++ b/missalemeum/static/js/common.js
@@ -8,6 +8,7 @@ const $buttonSidebarCollapse = $("button#sidebar-collapse");
 const langSwithVernacular = "lang-switch-vernacular";
 const $sidebar = $("nav#sidebar");
 const $sidebarTools = $("div#sidebar-tools");
+const $metaThemeColor = $('meta[name="theme-color"]');
 
 const $templateSidebarCalendarItem = $("#template-sidebar-item").text();
 const $templateSidebarCalendarItemYear = $("#template-sidebar-item-year").text();
@@ -102,6 +103,7 @@ function setDarkTheme() {
     localStorage.setItem("theme", "dark");
     document.body.classList.add("dark-theme");
     document.body.classList.remove("light-theme");
+    $metaThemeColor.attr("content", "#262626");
 }
 
 function setLightTheme() {
@@ -109,6 +111,7 @@ function setLightTheme() {
     localStorage.setItem("theme", "light");
     document.body.classList.remove("dark-theme");
     document.body.classList.add("light-theme");
+    $metaThemeColor.attr("content", "#fffdf1");
 }
 
 function setAutoTheme() {
@@ -116,6 +119,9 @@ function setAutoTheme() {
     localStorage.removeItem("theme");
     document.body.classList.remove("dark-theme");
     document.body.classList.remove("light-theme");
+    if ( window.matchMedia('(prefers-color-scheme: dark)').matches){
+        $metaThemeColor.attr("content", "#262626");
+    }
 }
 
 function navbarIsCollapsed() {

--- a/missalemeum/templates/base.html
+++ b/missalemeum/templates/base.html
@@ -10,7 +10,8 @@
     <meta property="og:image" content="http://www.missalemeum.com/static/img/icon-192x192.png">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#fffdf1">
+    <meta name="theme-color" content="#262626" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#fffdf1" media="(prefers-color-scheme: light)">
     <link rel="alternate" hreflang="pl" href="https://www.missalemeum.com/pl" />
     <link rel="alternate" hreflang="en" href="https://www.missalemeum.com/en" />
     <link rel="manifest" href="/static/manifest/{{ lang }}/manifest.json">


### PR DESCRIPTION
On devices with a notch (iPhones for sure) the area around the notch
was light themed, despite the dark mode setting.

This fix makes this area match the background color of the site,
like in the light mode.

JavaScript must bo in control of this, to make the dynamic change
possible. Base.html is changed, because the area blinked from time to time
(it was rendered light and changed dynamically miliseconds later, it was visible).
I wanted it to match the expected initial value, to prevent that.