### PR TITLE
chore: update divinum-officium submodule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,25 @@
 
 - `pytest` correctly picks up `backend/pytest.ini` when invoked from the repo root.
 - If `pytest ...` or `python ...` fails, do not keep guessing; fall back to the command pattern above.
+
+## Fixture Drift After Divinum Officium Updates
+
+- For changes coming from the Divinum Officium submodule update branch `chore/update-divinum-officium-submodule`, most test failures are caused by fixtures no longer matching updated source texts.
+- This is only the majority case, not a rule. Every failure must be judged individually before changing fixtures.
+- Typical pattern:
+  - A proper, reading, or similar text differs only in wording, punctuation, accents, or other source-text details.
+  - The generated output matches the updated Divinum Officium source, but the stored fixture still reflects the old text.
+- How to handle it:
+  - Run the failing test with a narrow `-k` filter.
+  - Inspect the failure diff and identify the exact context.
+  - Compare the actual generated text with the current source text and, when useful, with CLI output such as `./.venv/bin/python3 backend/api/cli.py date 2025-02-03 --language en`.
+  - If the code output is correct and the source text changed upstream, update the relevant fixture.
+  - If the output indicates a logic bug, wrong proper selection, broken formatting, or another behavioral regression, fix the code instead of the fixture.
+
+## CLI
+
+Get texts for a given calendar day:
+
+```
+./.venv/bin/python3 backend/api/cli.py date 2025-02-03 --language en
+```

--- a/backend/tests/fixtures/propers_en.json
+++ b/backend/tests/fixtures/propers_en.json
@@ -6242,7 +6242,7 @@
   "2024-04-25": [
     [
       {
-        "body": "*Ps 63:3*\nThou hast protected me from the assembly of the malignant; from the multitude of the workers of iniquity. alle",
+        "body": "*Ps 63:3*\nThou hast protected me from the assembly of the malignant, alleluia: from the multitude of the workers of iniq",
         "id": "Introitus"
       },
       {


### PR DESCRIPTION
Automated weekly submodule refresh.

This PR updates `backend/resources/divinum-officium` to the latest upstream commit.
Merge manually after CI passes.